### PR TITLE
Derive storage path

### DIFF
--- a/cadence/contracts/example-app/ExampleApplication.cdc
+++ b/cadence/contracts/example-app/ExampleApplication.cdc
@@ -33,14 +33,12 @@ access(all) contract ExampleApplication {
         emit CommandApproved(commandId: commandId, sourceChain: sourceChain, sourceAddress: sourceAddress)
         return AxelarGateway.ExecutionStatus(
           isExecuted: true,
-          statusCode: 0,
-          errorMessage: ""
+          errorMessage: nil
         )
       }
 
       return AxelarGateway.ExecutionStatus(
         isExecuted: false,
-        statusCode: 1,
         errorMessage: "Could not insert gmp data"
       )
     }


### PR DESCRIPTION
Restricting error message length to 20 characters.
Removed status code from execution status as it is not being used and to save on storage.
Added EternalStorage resource for storing executed commands in different directories.
Added a method for deriving a storage path from command id.